### PR TITLE
Link and include protobuf libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ DEBUG_ON ?= 0
 VERSION = 1.0
 
 # Compiler/linker flags
-CFLAGS += -g -Wall -DLOGGER=$(LOGGER) -DVERSION=$(VERSION) -DDEBUG_ON=$(DEBUG_ON)
-LDLIBS +=
+CFLAGS += -g -Wall -pthread -I/usr/include/protobuf-c -DLOGGER=$(LOGGER) -DVERSION=$(VERSION) -DDEBUG_ON=$(DEBUG_ON)
+LDLIBS += -lprotobuf-c 
 LDFLAGS +=
 
 src=server.c common.c task.c sha1.c

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ bin=coin-server
 # Set the following to '0' to disable log messages:
 LOGGER ?= 1
 DEBUG_ON ?= 0
-VERSION = 1.0
+VERSION = 2.0
 
 # Compiler/linker flags
 CFLAGS += -g -Wall -pthread -I/usr/include/protobuf-c -DLOGGER=$(LOGGER) -DVERSION=$(VERSION) -DDEBUG_ON=$(DEBUG_ON)


### PR DESCRIPTION
Addresses #50 

Updated the Makefile to include protobuf libraries and link against the library during the build process.

Also bumped the version of coin-server to 2.0.