### PR TITLE
Fix: Close client socket fd on early returns to prevent resource leak

### DIFF
--- a/server.c
+++ b/server.c
@@ -280,11 +280,13 @@ void *client_thread(void* client_fd) {
        ssize_t bytes_read = read_msg(fd, &msg);
        if(bytes_read == -1){
             perror("read_msg");
+	    close(fd); // Making sure to close the socket
             return NULL;
        }
        else if (bytes_read == 0) {
            LOGP("Disconnecting client\n");
-            return NULL;
+           close(fd); // Making sure to close the socket
+           return NULL;
        }
        if (difftime(time(NULL), task_start_time) > 24 * 60 * 60) {
             generate_new_task();
@@ -302,7 +304,7 @@ void *client_thread(void* client_fd) {
                 LOG("ERROR: unknown message type: %d\n", msg.header.msg_type);
         }
     }
-    close(fd);
+    close(fd); // Wont ever reach this but I am keeping it as a memento to whoeevr put it here
     return NULL;
 }
 

--- a/server.c
+++ b/server.c
@@ -274,19 +274,20 @@ void handle_solution(int fd, struct msg_solution *solution)
 
 void *client_thread(void* client_fd) {
     int fd = (int) (long) client_fd;
+    bool should_exit = false; // Flag to see if we should exit the while loop
     while (true) {
 
       union msg_wrapper msg;
        ssize_t bytes_read = read_msg(fd, &msg);
        if(bytes_read == -1){
             perror("read_msg");
-	    close(fd); // Making sure to close the socket
-            return NULL;
+	    should_exit = true; // Break out of the loop
+            break;
        }
        else if (bytes_read == 0) {
            LOGP("Disconnecting client\n");
-           close(fd); // Making sure to close the socket
-           return NULL;
+           should_exit = true; // Break out of the loop
+           break;
        }
        if (difftime(time(NULL), task_start_time) > 24 * 60 * 60) {
             generate_new_task();
@@ -304,7 +305,8 @@ void *client_thread(void* client_fd) {
                 LOG("ERROR: unknown message type: %d\n", msg.header.msg_type);
         }
     }
-    close(fd); // Wont ever reach this but I am keeping it as a memento to whoeevr put it here
+    // Once we break we close and return null
+    close(fd);
     return NULL;
 }
 

--- a/server.c
+++ b/server.c
@@ -274,19 +274,16 @@ void handle_solution(int fd, struct msg_solution *solution)
 
 void *client_thread(void* client_fd) {
     int fd = (int) (long) client_fd;
-    bool should_exit = false; // Flag to see if we should exit the while loop
     while (true) {
 
       union msg_wrapper msg;
        ssize_t bytes_read = read_msg(fd, &msg);
        if(bytes_read == -1){
             perror("read_msg");
-	    should_exit = true; // Break out of the loop
             break;
        }
        else if (bytes_read == 0) {
            LOGP("Disconnecting client\n");
-           should_exit = true; // Break out of the loop
            break;
        }
        if (difftime(time(NULL), task_start_time) > 24 * 60 * 60) {


### PR DESCRIPTION
This fixes a resource leak in the client_thread function. Previously, when a client disconnected or an error occurred during message reading, the thread would return without properly closing the file descriptor.

The fix ensures that the fd is properly closed before the thread returns in all cases, preventing potential resource leaks.