### PR TITLE
Implement alpha-quality support for protocol buffers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ DEBUG_ON ?= 0
 VERSION = 2.0
 
 # Compiler/linker flags
-CFLAGS += -g -Wall -pthread -I/usr/include/protobuf-c -DLOGGER=$(LOGGER) -DVERSION=$(VERSION) -DDEBUG_ON=$(DEBUG_ON)
+CFLAGS += -g -Wall -pthread -I/usr/include/protobuf-c \
+	  -DLOGGER=$(LOGGER) -DVERSION=$(VERSION) -DDEBUG_ON=$(DEBUG_ON)
 LDLIBS += -lprotobuf-c 
 LDFLAGS +=
 
-src=server.c common.c task.c sha1.c
+src=server.c common.c task.c sha1.c coin-messages.pb-c.c
 obj=$(src:.c=.o)
 
 all: $(bin)
@@ -19,11 +20,15 @@ all: $(bin)
 $(bin): $(obj)
 	$(CC) $(CFLAGS) $(LDLIBS) $(LDFLAGS) $(obj) -o $@
 
-server.o: server.h server.c common.o logger.h
-common.o: common.h logger.h
+coin-messages.pb-c.h: coin-messages.proto
+	protoc coin-messages.proto --c_out=./
+	protoc coin-messages.proto --python_out=./demo-client
+
+server.o: server.h server.c common.o logger.h coin-messages.pb-c.h
+common.o: common.h logger.h coin-messages.pb-c.h
 task.o: task.h task.c logger.h
 sha1.o: sha1.c sha1.h
+coin-messages.pb-c.o: coin-messages.pb-c.c coin-messages.pb-c.h coin-messages.proto
 
 clean:
 	rm -f $(bin) $(obj) vgcore.*
-

--- a/common.c
+++ b/common.c
@@ -1,11 +1,15 @@
 #include "common.h"
+#include <arpa/inet.h>
 #include <unistd.h>
 #include <errno.h>
 
+#include "coin-messages.pb-c.h"
 #include <stdbool.h>
 #include <assert.h>
+#include <stdlib.h>
+#include "logger.h"
 
-int read_len(int fd, void *buf, size_t length)
+ssize_t read_len(int fd, void *buf, size_t length)
 {
   size_t total = 0;
   while (total < length) {
@@ -34,7 +38,7 @@ int read_len(int fd, void *buf, size_t length)
   return total;
 }
 
-int write_len(const int fd, const void *buf, size_t length)
+ssize_t write_len(const int fd, const void *buf, size_t length)
 {
   size_t total = 0;
   while (total < length) {
@@ -44,8 +48,8 @@ int write_len(const int fd, const void *buf, size_t length)
             // if we get interrupted then we should try reading again
             continue;
         }
-      // read error
-      perror("write");
+      // write error
+      perror("write_len");
       return -1;
     }
 
@@ -96,6 +100,31 @@ int read_msg(int fd, union msg_wrapper *msg)
   return total_size;
 }
 
+CoinMsg__Envelope *recv_envelope(int fd)
+{
+    uint32_t msg_size;
+    ssize_t prefix_bytes = read_len(fd, &msg_size, sizeof(uint32_t));
+    if (prefix_bytes == 0 || prefix_bytes == -1) {
+      perror("read_len");
+      return NULL;
+    }
+
+  msg_size = ntohl(msg_size);
+    LOG("Receiving message wrapper, size: %u\n", msg_size);
+    void *buf = malloc(msg_size);
+    ssize_t wrapper_bytes = read_len(fd, buf, msg_size);
+    if (wrapper_bytes == -1 || wrapper_bytes == 0) {
+      perror("read_len");
+        free(buf);
+        return NULL;
+    }
+
+    CoinMsg__Envelope *envelope
+        = coin_msg__envelope__unpack(NULL, msg_size, buf);
+    free(buf);
+    return envelope;
+}
+
 int write_msg(int fd, const union msg_wrapper *msg)
 {
   return write_len(fd, msg, msg->header.msg_len);
@@ -109,4 +138,56 @@ union msg_wrapper create_msg(enum MSG_TYPES type)
   return wrapper;
 }
 
-// 
+ssize_t write_envelope(int fd, const CoinMsg__Envelope *envelope)
+{
+  size_t resp_sz = coin_msg__envelope__get_packed_size(envelope);
+  void *buf = malloc(resp_sz);
+  coin_msg__envelope__pack(envelope, buf);
+
+  uint32_t net_prefix = htonl(resp_sz);
+  write_len(fd, &net_prefix, sizeof(uint32_t));
+  ssize_t result = write_len(fd, buf, resp_sz);
+  free(buf);
+  return result;
+}
+
+
+void send_registration_reply(int fd, bool ok)
+{
+  CoinMsg__RegistrationReply reply = COIN_MSG__REGISTRATION_REPLY__INIT;
+  reply.ok = ok;
+
+  CoinMsg__Envelope envelope = COIN_MSG__ENVELOPE__INIT;
+  envelope.registration_reply = &reply;
+  envelope.body_case = COIN_MSG__ENVELOPE__BODY_REGISTRATION_REPLY;
+
+  write_envelope(fd, &envelope);
+}
+
+void send_task_reply(
+  int fd, char *block, uint32_t difficulty_mask, uint64_t sequence_num)
+{
+  CoinMsg__TaskReply reply = COIN_MSG__TASK_REPLY__INIT;
+  reply.block = block;
+  reply.difficulty_mask = difficulty_mask;
+  reply.sequence_num = sequence_num;
+
+  CoinMsg__Envelope envelope = COIN_MSG__ENVELOPE__INIT;
+  envelope.task_reply = &reply;
+  envelope.body_case = COIN_MSG__ENVELOPE__BODY_TASK_REPLY;
+
+  write_envelope(fd, &envelope);
+}
+
+void send_verification_reply(int fd, bool ok, char *diagnostic)
+{
+  CoinMsg__VerificationReply reply = COIN_MSG__VERIFICATION_REPLY__INIT;
+  reply.ok = ok;
+  reply.diagnostic = diagnostic;
+
+  CoinMsg__Envelope envelope = COIN_MSG__ENVELOPE__INIT;
+  envelope.verification_reply = &reply;
+  envelope.body_case = COIN_MSG__ENVELOPE__BODY_VERIFICATION_REPLY;
+
+  write_envelope(fd, &envelope);
+}

--- a/common.h
+++ b/common.h
@@ -6,12 +6,15 @@
 #include <inttypes.h>
 
 #include "task.h"
+#include "coin-messages.pb-c.h"
 
 #ifndef DEBUG_ON
 #define DEBUG_ON 1
 #endif
 
 #define MAX_USER_LEN 24
+
+CoinMsg__Envelope *recv_envelope(int fd);
 
 struct __attribute__((__packed__)) msg_header {
     uint64_t msg_len;
@@ -87,14 +90,18 @@ size_t msg_size(enum MSG_TYPES type);
  *  * length - size of the incoming message. If less than 'length' bytes are
  *             received, we'll keep retrying the read() operation.
  */
-int read_len(int fd, void *buf, size_t length);
+ssize_t read_len(int fd, void *buf, size_t length);
 
-int write_len(const int fd, const void *buf, size_t length);
+ssize_t write_len(const int fd, const void *buf, size_t length);
 
 union msg_wrapper create_msg(enum MSG_TYPES type);
 
 int read_msg(int fd, union msg_wrapper *msg);
 
 int write_msg(int fd, const union msg_wrapper *msg);
+
+void send_registration_reply(int fd, bool ok);
+void send_task_reply(int fd, char *block, uint32_t difficulty_mask, uint64_t sequence_num);
+void send_verification_reply(int fd, bool ok, char *diagnostic);
 
 #endif


### PR DESCRIPTION
This adapts the chat example to use protocol buffers for communication. There are still pieces that have not been migrated (heartbeats) but this represents a reasonable starting point that we can work from.

Long term, we need to remove the remnants of the old messaging format to simplify the codebase.

This should also close #63.