### PR TITLE
Fix: Issue #68, 24 hour task rotation thread

### DIFF
--- a/server.c
+++ b/server.c
@@ -342,7 +342,6 @@ void* task_reset_thread(void* arg) {
 	    if (now - task_start_time > 86400) {
 		    generate_new_task();
 		    task_start_time = now;
-		    log_info("Task reset after 24 hours of inactivity");
 	    }
 	    pthread_mutex_unlock(&lock);
     }


### PR DESCRIPTION
Added a new method to `server.c`: 'task_reset_thread()`...
This method runs in a background thread that checks if the current task has been unsolved for > 24 hours. The thread is started in after initial task generation.