### PR TITLE
Global mutable user_list without synchronization

### DIFF
--- a/server.c
+++ b/server.c
@@ -153,6 +153,11 @@ struct user *add_user(char *username)
     }
 
     struct user *u = calloc(1, sizeof(struct user));
+    if (u == NULL) {
+        perror("calloc");
+        pthread_mutex_unlock(&user_list_lock);
+        return NULL;
+    }
 
     strncpy(u->username, username, MAX_USER_LEN);
     u->username[MAX_USER_LEN - 1] = '\0'; // safer null-termination

--- a/server.c
+++ b/server.c
@@ -153,11 +153,6 @@ struct user *add_user(char *username)
     }
 
     struct user *u = calloc(1, sizeof(struct user));
-    if (u == NULL) {
-        perror("calloc");
-        pthread_mutex_unlock(&user_list_lock);
-        return NULL;
-    }
 
     strncpy(u->username, username, MAX_USER_LEN);
     u->username[MAX_USER_LEN - 1] = '\0'; // safer null-termination


### PR DESCRIPTION
add_user() and find_user() modify and traverse user_list, but user_list is not protected by a mutex. This could result in race conditions with concurrent clients.

Fix: Make a new mutex to protect user_list

Revised code:

Line 31: Initialized pthread_mutex_t user_list_lock 
Line 129: Locked the mutex in find_user
Line 138: Unlocked the mutex in find_user
Line 144: Locked the mutex in add_user
                Removed: 
                     struct user* existing = find_user(username);
                     if (existing != NULL) { return NULL; }
                This is because calling find_user without any synchronization and then modifying user_list can open up the possibility of a race 
                condition. Two threads could call find_user at the same time, both not find the user, and both allocate and add a duplicate user. 
                Checking for an existing user and inserting if a user is not found while inside the mutex user_list_lock guarantees that no two threads 
                can do these things at the same time.
Line 156: Added error handling for calloc() operation
Line 168: Unlocked the mutex in add_user
Line 494: Destroyed mutex at the end of the program