### PR TITLE
Clean up all old networking code and add user_manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CFLAGS += -g -Wall -pthread -I/usr/include/protobuf-c \
 LDLIBS += -lprotobuf-c 
 LDFLAGS +=
 
-src=server.c common.c task.c sha1.c coin-messages.pb-c.c
+src=server.c common.c task.c sha1.c coin-messages.pb-c.c user_manager.c
 obj=$(src:.c=.o)
 
 all: $(bin)
@@ -20,7 +20,9 @@ all: $(bin)
 $(bin): $(obj)
 	$(CC) $(CFLAGS) $(LDLIBS) $(LDFLAGS) $(obj) -o $@
 
-coin-messages.pb-c.h: coin-messages.proto
+proto_out=coin-messages.pb-c.h coin-messages.pb-c.c \
+	  ./demo-client/coin_messages_pb2.py
+$(proto_out): coin-messages.proto
 	protoc coin-messages.proto --c_out=./
 	protoc coin-messages.proto --python_out=./demo-client
 
@@ -28,7 +30,8 @@ server.o: server.h server.c common.o logger.h coin-messages.pb-c.h
 common.o: common.h logger.h coin-messages.pb-c.h
 task.o: task.h task.c logger.h
 sha1.o: sha1.c sha1.h
+user_manager.o: user_manager.c user_manager.h
 coin-messages.pb-c.o: coin-messages.pb-c.c coin-messages.pb-c.h coin-messages.proto
 
 clean:
-	rm -f $(bin) $(obj) vgcore.*
+	rm -f $(bin) $(obj) $(proto_out) vgcore.*

--- a/common.h
+++ b/common.h
@@ -14,71 +14,6 @@
 
 #define MAX_USER_LEN 24
 
-CoinMsg__Envelope *recv_envelope(int fd);
-
-struct __attribute__((__packed__)) msg_header {
-    uint64_t msg_len;
-    uint16_t msg_type;
-};
-
-struct __attribute__((__packed__)) msg_request_task {
-    struct msg_header header;
-    char username[MAX_USER_LEN];
-};
-
-struct __attribute__((__packed__)) msg_task {
-        struct msg_header header;
-        char block[MAX_BLOCK_LEN];
-        uint32_t difficulty_mask;
-        uint64_t sequence_num;
-};
-
-struct __attribute__((__packed__)) msg_solution {
-        struct msg_header header;
-        char username[MAX_USER_LEN];
-        char block[MAX_BLOCK_LEN];
-        uint32_t difficulty_mask;
-        uint64_t nonce;
-        uint64_t sequence_num;
-};
-
-struct __attribute__((__packed__)) msg_verification {
-        struct msg_header header;
-        bool ok;
-        char error_description[128];
-};
-
-struct __attribute__((__packed__)) msg_heartbeat {
-        struct msg_header header;
-        char username[MAX_USER_LEN];
-};
-
-struct __attribute__((__packed__)) msg_heartbeat_reply {
-        struct msg_header header;
-        uint64_t sequence_num;
-};
-
-union __attribute__((__packed__)) msg_wrapper {
-        struct msg_header header;
-        struct msg_request_task request_task;
-        struct msg_task task;
-        struct msg_solution solution;
-        struct msg_verification verification;
-        struct msg_heartbeat heartbeat;
-        struct msg_heartbeat_reply heartbeat_reply;
-};
-
-enum MSG_TYPES {
-        MSG_REQUEST_TASK,
-        MSG_TASK,
-        MSG_SOLUTION,
-        MSG_VERIFICATION,
-        MSG_HEARTBEAT,
-        MSG_HEARTBEAT_REPLY,
-};
-
-size_t msg_size(enum MSG_TYPES type);
-
 /**
  * Function: read_len
  * Purpose:  reads from an input stream, retrying until a specific number of
@@ -94,11 +29,7 @@ ssize_t read_len(int fd, void *buf, size_t length);
 
 ssize_t write_len(const int fd, const void *buf, size_t length);
 
-union msg_wrapper create_msg(enum MSG_TYPES type);
-
-int read_msg(int fd, union msg_wrapper *msg);
-
-int write_msg(int fd, const union msg_wrapper *msg);
+CoinMsg__Envelope *recv_envelope(int fd);
 
 void send_registration_reply(int fd, bool ok);
 void send_task_reply(int fd, char *block, uint32_t difficulty_mask, uint64_t sequence_num);

--- a/user_manager.c
+++ b/user_manager.c
@@ -1,0 +1,87 @@
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "user_manager.h"
+
+struct user_node {
+    char *username;
+    struct user_node *next;
+};
+
+static struct user_node *user_list = NULL;
+static pthread_mutex_t user_mutex;
+
+void delete_node(struct user_node *node)
+{
+    free(node->username); // strdup'd during initialization
+    free(node);
+}
+
+void user_manager_destroy() {
+    pthread_mutex_lock(&user_mutex);
+    struct user_node *curr = user_list;
+    while (curr) {
+        struct user_node *tmp = curr;
+        curr = curr->next;
+        delete_node(tmp);
+    }
+    user_list = NULL;
+    pthread_mutex_unlock(&user_mutex);
+    pthread_mutex_destroy(&user_mutex);
+}
+
+bool user_remove(char *username) {
+    pthread_mutex_lock(&user_mutex);
+
+    struct user_node *curr = user_list;
+    struct user_node *prev = NULL;
+    while (curr) {
+        if (strcmp(curr->username, username) == 0) {
+            if (prev == NULL) {
+                user_list = curr->next;
+                delete_node(curr);
+                pthread_mutex_unlock(&user_mutex);
+                return true;
+            } else {
+                prev->next = curr->next;
+                delete_node(curr);
+                pthread_mutex_unlock(&user_mutex);
+                return true;
+            }
+        }
+        prev = curr;
+        curr = curr->next;
+    }
+
+    pthread_mutex_unlock(&user_mutex);
+    return false;
+}
+
+bool user_register(char *username) {
+    pthread_mutex_lock(&user_mutex);
+
+    struct user_node *curr = user_list;
+    while (curr != NULL) {
+        if (strcmp(curr->username, username) == 0) {
+            pthread_mutex_unlock(&user_mutex);
+            return false;  
+        }
+        curr = curr->next;
+    }
+
+    struct user_node *new_node = calloc(1, sizeof(struct user_node));
+    if (new_node == NULL) {
+        pthread_mutex_unlock(&user_mutex);
+        return NULL;
+    }
+
+    new_node->username = strdup(username);
+    new_node->next = user_list;
+    user_list = new_node;
+
+    pthread_mutex_unlock(&user_mutex);
+    return true;
+}
+

--- a/user_manager.h
+++ b/user_manager.h
@@ -1,0 +1,8 @@
+#ifndef USER_MANAGER_H
+#define USER_MANAGER_H
+
+bool user_register(char *username);
+bool user_remove(char *username);
+void user_manager_destroy();
+
+#endif


### PR DESCRIPTION
* This finishes up the job of removing old messaging code, closes #65.
* Moves to a completely decoupled user tracking system wherein we no longer need to acquire locks for basic user metadata. Now registrations are handled via the user_manager provided by Lexi in #70. This also closes #69.
* Addresses part of the issue in #78 but the heartbeat logic still needs to be filled in.